### PR TITLE
adding debug output of JWT data

### DIFF
--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -147,6 +147,8 @@ static ngx_int_t ngx_http_auth_jwt_handler(ngx_http_request_t *r)
     return NGX_HTTP_UNAUTHORIZED;
   }
 
+  ngx_log_error(NGX_LOG_DEBUG, r->connection->log, 0,"Found JWT: %s", jwt_data);
+
   // Validate the jwt
   if (jwt_decode(&jwt, jwt_data, conf->jwt_key.data, conf->jwt_key.len))
   {

--- a/src/ngx_http_auth_jwt_module.c
+++ b/src/ngx_http_auth_jwt_module.c
@@ -470,7 +470,14 @@ static ngx_int_t auth_jwt_get_token(char ** token, ngx_http_request_t *r, const 
       return NGX_DECLINED;
     }
 
-    *token = (char *) value->data;
+    *token = ngx_pcalloc(r->pool, value->len + 1);
+    if (token == NULL)
+    {
+      ngx_log_error(NGX_LOG_WARN, r->connection->log, 0, "Could not allocate memory.");
+      return NGX_ERROR;
+    }
+    ngx_memcpy(token, value->data, value->len);
+
     return NGX_OK;
   }
   else


### PR DESCRIPTION
I added a debug log statement in case one would like to print out the JWT data that is put into `jwt_decode`.